### PR TITLE
Add support for webpack 2 and safari

### DIFF
--- a/index.es6.js
+++ b/index.es6.js
@@ -3,7 +3,7 @@ import metadata from 'libphonenumber-js/metadata.min.json'
 
 import CustomInput from './es6/input'
 
-export const Input = CustomInput
+export var Input = CustomInput
 
 export default function Phone(props)
 {


### PR DESCRIPTION
When used as node module with webpack 2 on safari it fails with: 

`Const declarations are not supported in strict mode.`

