### PR TITLE
add support for onKeyDown event

### DIFF
--- a/source/input.js
+++ b/source/input.js
@@ -52,6 +52,10 @@ export default class Input extends Component
 		//  to make sure it works correctly with `redux-form`)
 		onBlur : PropTypes.func,
 
+		// Set 'onKeyDown' handler
+		// Can be used in special cases to handle e.g. enter pressed
+        onKeyDown: PropTypes.func,
+
 		// Disables both the <input/> and the <select/>
 		// (is `false` by default)
 		disabled : PropTypes.bool.isRequired,
@@ -468,11 +472,15 @@ export default class Input extends Component
 	// `<input/>` `onKeyDown` handler
 	on_key_down(event)
 	{
+		const {onKeyDown} = this.props
+
 		// Expand country `<select/>`` on "Down arrow" key press
 		if (event.keyCode === 40)
 		{
 			this.select.toggle()
 		}
+
+        onKeyDown(event)
 	}
 
 	// `<input/>` `onChange` handler.

--- a/source/input.js
+++ b/source/input.js
@@ -54,7 +54,7 @@ export default class Input extends Component
 
 		// Set 'onKeyDown' handler
 		// Can be used in special cases to handle e.g. enter pressed
-        onKeyDown: PropTypes.func,
+		onKeyDown: PropTypes.func,
 
 		// Disables both the <input/> and the <select/>
 		// (is `false` by default)
@@ -480,7 +480,7 @@ export default class Input extends Component
 			this.select.toggle()
 		}
 
-        onKeyDown(event)
+		onKeyDown(event)
 	}
 
 	// `<input/>` `onChange` handler.

--- a/source/input.js
+++ b/source/input.js
@@ -54,7 +54,7 @@ export default class Input extends Component
 
 		// Set 'onKeyDown' handler
 		// Can be used in special cases to handle e.g. enter pressed
-		onKeyDown: PropTypes.func,
+		onKeyDown : PropTypes.func,
 
 		// Disables both the <input/> and the <select/>
 		// (is `false` by default)
@@ -472,7 +472,7 @@ export default class Input extends Component
 	// `<input/>` `onKeyDown` handler
 	on_key_down(event)
 	{
-		const {onKeyDown} = this.props
+		const { onKeyDown } = this.props
 
 		// Expand country `<select/>`` on "Down arrow" key press
 		if (event.keyCode === 40)
@@ -480,7 +480,10 @@ export default class Input extends Component
 			this.select.toggle()
 		}
 
-		onKeyDown(event)
+		if(onKeyDown)
+		{
+			onKeyDown(event)
+		}
 	}
 
 	// `<input/>` `onChange` handler.

--- a/source/input.js
+++ b/source/input.js
@@ -480,7 +480,7 @@ export default class Input extends Component
 			this.select.toggle()
 		}
 
-		if(onKeyDown)
+		if (onKeyDown)
 		{
 			onKeyDown(event)
 		}

--- a/source/input.js
+++ b/source/input.js
@@ -52,7 +52,7 @@ export default class Input extends Component
 		//  to make sure it works correctly with `redux-form`)
 		onBlur : PropTypes.func,
 
-		// Set 'onKeyDown' handler
+		// Set `onKeyDown` handler.
 		// Can be used in special cases to handle e.g. enter pressed
 		onKeyDown : PropTypes.func,
 


### PR DESCRIPTION
Add support for onKeyDown event:
- Can be used in situations where you need to handle e.g. 'Enter' key pressed