### PR TITLE
Fixing custom country names sort

### DIFF
--- a/source/input.js
+++ b/source/input.js
@@ -258,7 +258,7 @@ export default class Input extends Component
 		//
 		if (using_custom_country_names && String.prototype.localeCompare)
 		{
-			this.select_options.sort((a, b) => a.localeCompare(b))
+			this.select_options.sort((a, b) => a['label'].localeCompare(b['label']))
 		}
 
 		// Add the "International" option to the country list (if suitable)

--- a/source/input.js
+++ b/source/input.js
@@ -258,7 +258,7 @@ export default class Input extends Component
 		//
 		if (using_custom_country_names && String.prototype.localeCompare)
 		{
-			this.select_options.sort((a, b) => a['label'].localeCompare(b['label']))
+			this.select_options.sort((a, b) => a.label.localeCompare(b.label))
 		}
 
 		// Add the "International" option to the country list (if suitable)


### PR DESCRIPTION
Now `localeCompare` compares object 
{
value : country_code,
label : dictionary[country_code] || default_dictionary[country_code],
icon  : get_country_option_icon(country_code, this.props)
}
Expected string.